### PR TITLE
oppo-common: ConfigPanel: Remove swap buttons support

### DIFF
--- a/configpanel/res/xml/button_panel.xml
+++ b/configpanel/res/xml/button_panel.xml
@@ -16,11 +16,6 @@
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <SwitchPreference
-        android:key="button_swap"
-        android:title="@string/button_swap_title"
-        android:summary="@string/button_swap_summary" />
-
     <PreferenceCategory
         android:title="@string/notification_slider_category_title">
 

--- a/configpanel/src/org/lineageos/settings/device/Startup.java
+++ b/configpanel/src/org/lineageos/settings/device/Startup.java
@@ -86,8 +86,7 @@ public class Startup extends BroadcastReceiver {
     static boolean hasButtonProcs() {
         return (FileUtils.fileExists(Constants.NOTIF_SLIDER_TOP_NODE) &&
                 FileUtils.fileExists(Constants.NOTIF_SLIDER_MIDDLE_NODE) &&
-                FileUtils.fileExists(Constants.NOTIF_SLIDER_BOTTOM_NODE)) ||
-                FileUtils.fileExists(Constants.BUTTON_SWAP_NODE);
+                FileUtils.fileExists(Constants.NOTIF_SLIDER_BOTTOM_NODE));
     }
 
     static boolean hasOClick() {

--- a/configpanel/src/org/lineageos/settings/device/utils/Constants.java
+++ b/configpanel/src/org/lineageos/settings/device/utils/Constants.java
@@ -35,13 +35,11 @@ public class Constants {
     public static final String OCLICK_FIND_PHONE_KEY = "oclick_find_my_phone";
     public static final String OCLICK_FENCE_KEY = "oclick_fence";
     public static final String OCLICK_DISCONNECT_ALERT_KEY = "oclick_disconnect_alert";
-    public static final String BUTTON_SWAP_KEY = "button_swap";
     public static final String NOTIF_SLIDER_TOP_KEY = "keycode_top_position";
     public static final String NOTIF_SLIDER_MIDDLE_KEY = "keycode_middle_position";
     public static final String NOTIF_SLIDER_BOTTOM_KEY = "keycode_bottom_position";
 
     // Button nodes
-    public static final String BUTTON_SWAP_NODE = "/proc/s1302/key_rep";
     public static final String NOTIF_SLIDER_TOP_NODE = "/proc/tri-state-key/keyCode_top";
     public static final String NOTIF_SLIDER_MIDDLE_NODE = "/proc/tri-state-key/keyCode_middle";
     public static final String NOTIF_SLIDER_BOTTOM_NODE = "/proc/tri-state-key/keyCode_bottom";
@@ -54,19 +52,16 @@ public class Constants {
     public static final Map<String, Object> sNodeDefaultMap = new HashMap<>();
 
     public static final String[] sButtonPrefKeys = {
-        BUTTON_SWAP_KEY,
         NOTIF_SLIDER_TOP_KEY,
         NOTIF_SLIDER_MIDDLE_KEY,
         NOTIF_SLIDER_BOTTOM_KEY
     };
 
     static {
-        sBooleanNodePreferenceMap.put(BUTTON_SWAP_KEY, BUTTON_SWAP_NODE);
         sStringNodePreferenceMap.put(NOTIF_SLIDER_TOP_KEY, NOTIF_SLIDER_TOP_NODE);
         sStringNodePreferenceMap.put(NOTIF_SLIDER_MIDDLE_KEY, NOTIF_SLIDER_MIDDLE_NODE);
         sStringNodePreferenceMap.put(NOTIF_SLIDER_BOTTOM_KEY, NOTIF_SLIDER_BOTTOM_NODE);
 
-        sNodeDefaultMap.put(BUTTON_SWAP_KEY, false);
         sNodeDefaultMap.put(NOTIF_SLIDER_TOP_KEY, "601");
         sNodeDefaultMap.put(NOTIF_SLIDER_MIDDLE_KEY, "602");
         sNodeDefaultMap.put(NOTIF_SLIDER_BOTTOM_KEY, "603");


### PR DESCRIPTION
Devices can now implement KeySwapper interface in the Touch HAL.

Change-Id: I75ec3c6ea64d64f8116ee13a1031ba87585ecede